### PR TITLE
fix: add support to unit tests

### DIFF
--- a/templates/.travis/scripts/execute-tests.sh
+++ b/templates/.travis/scripts/execute-tests.sh
@@ -1,14 +1,33 @@
 #!/usr/bin/env bash
 
-cd ${TRAVIS_BUILD_DIR}
-
 DOCROOT=$1
 MODULE_NAME=$(basename ${TRAVIS_BUILD_DIR})
 PHPUNIT=$(dirname ${DOCROOT})/$(composer config bin-dir)/phpunit
+COMPOSER="$(which composer)"
+PACKAGE_NAME=$(cat ${TRAVIS_BUILD_DIR}/composer.json|jq '.name'|sed -e 's:"::g')
 
+# Define the color scheme.
+FG_C='\033[1;37m'
+BG_C='\033[42m'
+WBG_C='\033[43m'
+EBG_C='\033[41m'
+NO_C='\033[0m'
+
+# Link the current module using composer. Otherwise the autoload will not have the necessary classes
+# for the Unit tests.
+cd ${DOCROOT}/.. || exit 2
+echo -e "${FG_C}${BG_C} EXECUTING ${NO_C} ${COMPOSER} require ${PACKAGE_NAME} \"phpunit/phpunit:^6.5\" --no-interaction --no-progress --no-suggest\n\n"
+${COMPOSER} require ${PACKAGE_NAME} "phpunit/phpunit:^6.5" --no-interaction --no-progress --no-suggest
+ls -lisa ${DOCROOT}/modules/contrib
+cat $( dirname ${DOCROOT} )/composer.json|jq ".repositories.${MODULE_NAME}"
+
+# Execute the static code analysis tasks.
+cd ${TRAVIS_BUILD_DIR} || exit 2
 /usr/local/share/chromedriver --port=4444 &
 php ./vendor/bin/grumphp run || exit 1
-cd ${DOCROOT}
+
+# Execute all the tests.
+cd ${DOCROOT} || exit 2
 perl -pe "s:\{DRUPAL_ROOT\}:${DOCROOT}:g" ${DOCROOT}/modules/contrib/${MODULE_NAME}/phpunit.xml.dist > ${DOCROOT}/modules/contrib/${MODULE_NAME}/phpunit.xml
 MINK_DRIVER_ARGS_WEBDRIVER='["chrome", {"chrome": {"switches":["headless"]}}, "http://localhost:4444"]' php ${PHPUNIT} \
   --configuration ${DOCROOT}/modules/contrib/${MODULE_NAME}/phpunit.xml \

--- a/templates/.travis/scripts/execute-tests.sh
+++ b/templates/.travis/scripts/execute-tests.sh
@@ -18,8 +18,6 @@ NO_C='\033[0m'
 cd ${DOCROOT}/.. || exit 2
 echo -e "${FG_C}${BG_C} EXECUTING ${NO_C} ${COMPOSER} require ${PACKAGE_NAME} \"phpunit/phpunit:^6.5\" --no-interaction --no-progress --no-suggest\n\n"
 ${COMPOSER} require ${PACKAGE_NAME} "phpunit/phpunit:^6.5" --no-interaction --no-progress --no-suggest
-ls -lisa ${DOCROOT}/modules/contrib
-cat $( dirname ${DOCROOT} )/composer.json|jq ".repositories.${MODULE_NAME}"
 
 # Execute the static code analysis tasks.
 cd ${TRAVIS_BUILD_DIR} || exit 2

--- a/templates/.travis/scripts/install-drupal.sh
+++ b/templates/.travis/scripts/install-drupal.sh
@@ -24,41 +24,35 @@ else
   echo -e "${FG_C}${WBG_C} WARNING ${NO_C} No installation path provided.\nDrupal will be installed in $DEST_DIR."
   echo -e "${FG_C}${BG_C} USAGE ${NO_C} ${0} [install_path] # to install in a different directory."
 fi
-DRUSH="$DEST_DIR/$COMPOSER_BIN_DIR/drush"
 
 echo -e "\n\n\n"
 echo -e "\t********************************"
 echo -e "\t*   Installing Dependencies    *"
 echo -e "\t********************************"
 echo -e "\n\n\n"
-echo -e "${FG_C}${BG_C} EXECUTING ${NO_C} $COMPOSER install\n\n"
-$COMPOSER install
+echo -e "${FG_C}${BG_C} EXECUTING ${NO_C} ${COMPOSER} install\n\n"
+${COMPOSER} install
 
 echo -e "\n\n\n"
 echo -e "\t********************************"
 echo -e "\t*      Installing Drupal       *"
 echo -e "\t********************************"
 echo -e "\n\n\n"
-echo -e "Installing to: $DEST_DIR\n"
+echo -e "Installing to: ${DEST_DIR}\n"
 
-if [ -d "$DEST_DIR" ]; then
-  echo -e "${FG_C}${WBG_C} WARNING ${NO_C} You are about to delete $DEST_DIR to install Drupal in that location."
-  rm -Rf $DEST_DIR
-  if [ $? -ne 0 ]; then
-    echo -e "${FG_C}${EBG_C} ERROR ${NO_C} Sometimes drush adds some files with permissions that are not deletable by the current user."
-    echo -e "${FG_C}${BG_C} EXECUTING ${NO_C} sudo rm -Rf $DEST_DIR"
-    sudo rm -Rf $DEST_DIR
-  fi
+if [ -d "${DEST_DIR}" ]; then
+  echo -e "${FG_C}${WBG_C} WARNING ${NO_C} You are about to delete ${DEST_DIR} to install Drupal in that location."
+  rm -Rf ${DEST_DIR}
 fi
 
 # update composer
-$COMPOSER self-update
+${COMPOSER} self-update
 
 echo "-----------------------------------------------"
 echo " Downloading Drupal using composer "
 echo "-----------------------------------------------"
-echo -e "${FG_C}${BG_C} EXECUTING ${NO_C} $COMPOSER create-project drupal-composer/drupal-project:8.x-dev ${DEST_DIR} --stability dev --no-interaction --no-install\n\n"
-$COMPOSER create-project drupal-composer/drupal-project:8.x-dev ${DEST_DIR} --stability dev --no-interaction --no-install
+echo -e "${FG_C}${BG_C} EXECUTING ${NO_C} ${COMPOSER} create-project drupal-composer/drupal-project:8.x-dev ${DEST_DIR} --stability dev --no-interaction --no-install\n\n"
+${COMPOSER} create-project drupal-composer/drupal-project:8.x-dev ${DEST_DIR} --stability dev --no-interaction --no-install
 
 if [ $? -ne 0 ]; then
   echo -e "${FG_C}${EBG_C} ERROR ${NO_C} There was a problem setting up Drupal using composer."
@@ -67,19 +61,16 @@ if [ $? -ne 0 ]; then
 fi
 
 cd ${DEST_DIR}
-$COMPOSER require "phpunit/phpunit:^6.5" --no-progress
+# Link the current module using composer. Otherwise the autoload will not have the necessary classes
+# for the Unit tests.
+echo -e "${FG_C}${BG_C} EXECUTING ${NO_C} ${COMPOSER} config repositories.${MODULE_NAME} path ${TRAVIS_BUILD_DIR}\n\n"
+${COMPOSER} config repositories.${MODULE_NAME} path ${TRAVIS_BUILD_DIR}
+cat ${DEST_DIR}/composer.json|jq ".repositories.${MODULE_NAME}"
 
 # Link the module directory into a location Drupal can find it.
 echo -e "${FG_C}${BG_C} EXECUTING ${NO_C} mkdir -p ${DEST_DIR}/${DOCROOT}/modules/contrib\n\n"
 mkdir -p ${DEST_DIR}/${DOCROOT}/modules/contrib
 mkdir -p ${DEST_DIR}/${DOCROOT}/sites/simpletest/browser_output
-
-# Link the current module using composer. Otherwise the autoload will not have the necessary classes
-# for the Unit tests.
-echo -e "${FG_C}${BG_C} EXECUTING ${NO_C} ${COMPOSER} config repositories.${MODULE_NAME} path ${TRAVIS_BUILD_DIR}\n\n"
-${COMPOSER} config repositories.${MODULE_NAME} path ${TRAVIS_BUILD_DIR}
-echo -e "${FG_C}${BG_C} EXECUTING ${NO_C} ${COMPOSER} require ${PACKAGE_NAME} --no-interaction --no-progress --no-suggest\n\n"
-${COMPOSER} require ${PACKAGE_NAME} --no-interaction --no-progress --no-suggest
 
 # This module depends on others. Since we are installing this manually (no composer) we need to pull
 # in the dependencies. They are in the vendor directory.


### PR DESCRIPTION
Link the module using composer path repositories. This way the autoloader will contain mappings for the Drupal classes and the project classes.