### PR TITLE
Fixes for v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
     "drupal/coder": "^8.2",
     "enlightn/security-checker": "^1.10",
-    "localheinz/composer-normalize": "^2.4",
+    "ergebnis/composer-normalize": "^2.30",
     "nikic/php-parser": "^4.2",
     "php-parallel-lint/php-parallel-lint": "^1.0",
     "phpmd/phpmd": "^2",
@@ -43,8 +43,8 @@
   "config": {
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true,
-      "localheinz/composer-normalize": true,
-      "phpro/grumphp-shim": true
+      "phpro/grumphp-shim": true,
+      "ergebnis/composer-normalize": true
     }
   },
   "extra": {

--- a/templates/grumphp.yml
+++ b/templates/grumphp.yml
@@ -15,7 +15,6 @@ grumphp:
         - types: ['build', 'ci', 'chore', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test']
         - scopes: ['schema', 'form', 'drupal', 'api']
       max_subject_width: 50
-      enforce_no_subject_punctuations: true
       enforce_no_subject_trailing_period: true
     git_branch_name:
       whitelist:


### PR DESCRIPTION
Found a couple of small issues with the recent v2:

* The `enforce_no_subject_punctuations` means that you can't use conventional commits `!` marker to [mark a commit as breaking](https://www.conventionalcommits.org/en/v1.0.0/#summary), eg. 

```
feat!: send an email to the customer when a product is shipped
```
* The `localheinz/composer-normalize` package is abandoned in favor of `ergebnis/composer-normalize`